### PR TITLE
Improve project setup

### DIFF
--- a/etc/Jenkinsfile.local
+++ b/etc/Jenkinsfile.local
@@ -11,7 +11,6 @@ node {
         }
 
         recordIssues tools: [java(), javaDoc()], aggregatingResults: 'true', id: 'java', name: 'Java'
-        recordIssues tool: errorProne(), healthy: 1, unhealthy: 20
 
         junit testResults: '**/target/*-reports/TEST-*.xml'
 

--- a/etc/Jenkinsfile.local
+++ b/etc/Jenkinsfile.local
@@ -1,0 +1,43 @@
+node {
+    def mvnHome = tool 'mvn-default'
+
+    stage ('Checkout') {
+        checkout scm
+    }
+
+    stage ('Build and Static Analysis') {
+        withMaven(maven: 'mvn-default', mavenLocalRepo: '/var/data/m2repository', mavenOpts: '-Xmx768m -Xms512m') {
+            sh 'mvn -ntp -V -e clean verify -Dmaven.test.failure.ignore -Dgpg.skip'
+        }
+
+        recordIssues tools: [java(), javaDoc()], aggregatingResults: 'true', id: 'java', name: 'Java'
+        recordIssues tool: errorProne(), healthy: 1, unhealthy: 20
+
+        junit testResults: '**/target/*-reports/TEST-*.xml'
+
+        recordIssues tools: [checkStyle(pattern: 'target/checkstyle-result.xml'),
+            spotBugs(pattern: 'target/spotbugsXml.xml'),
+            pmdParser(pattern: 'target/pmd.xml'),
+            cpd(pattern: 'target/cpd.xml'),
+            taskScanner(highTags:'FIXME', normalTags:'TODO', includePattern: '**/*.java', excludePattern: 'target/**/*')],
+            qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]
+    }
+
+    stage ('Line and Branch Coverage') {
+        withMaven(maven: 'mvn-default', mavenLocalRepo: '/var/data/m2repository', mavenOpts: '-Xmx768m -Xms512m') {
+            sh "mvn -ntp -V -U -e jacoco:prepare-agent test jacoco:report -Dmaven.test.failure.ignore"
+        }
+        publishCoverage adapters: [jacocoAdapter('**/*/jacoco.xml')], sourceFileResolver: sourceFiles('STORE_ALL_BUILD')
+    }
+
+    stage ('Mutation Coverage') {
+        withMaven(maven: 'mvn-default', mavenLocalRepo: '/var/data/m2repository', mavenOpts: '-Xmx768m -Xms512m') {
+            sh "mvn -ntp org.pitest:pitest-maven:mutationCoverage"
+        }
+        step([$class: 'PitPublisher', mutationStatsFile: 'target/pit-reports/**/mutations.xml'])
+    }
+
+    stage ('Autograding') {
+        autoGrade('{"analysis":{"maxScore":100,"errorImpact":-5,"highImpact":-2,"normalImpact":-1,"lowImpact":-1}, "tests":{"maxScore":100,"passedImpact":0,"failureImpact":-5,"skippedImpact":-1}, "coverage":{"maxScore":100,"coveredPercentageImpact":0,"missedPercentageImpact":-1}, "pit":{"maxScore":100,"detectedImpact":0,"undetectedImpact":0,"undetectedPercentageImpact":-1,"detectedPercentageImpact":0}}')
+    }
+}

--- a/etc/Jenkinsfile.local
+++ b/etc/Jenkinsfile.local
@@ -36,8 +36,4 @@ node {
         }
         step([$class: 'PitPublisher', mutationStatsFile: 'target/pit-reports/**/mutations.xml'])
     }
-
-    stage ('Autograding') {
-        autoGrade('{"analysis":{"maxScore":100,"errorImpact":-5,"highImpact":-2,"normalImpact":-1,"lowImpact":-1}, "tests":{"maxScore":100,"passedImpact":0,"failureImpact":-5,"skippedImpact":-1}, "coverage":{"maxScore":100,"coveredPercentageImpact":0,"missedPercentageImpact":-1}, "pit":{"maxScore":100,"detectedImpact":0,"undetectedImpact":0,"undetectedPercentageImpact":-1,"detectedPercentageImpact":0}}')
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,14 @@
       <version>${plugin-util-api.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>plugin-util-api</artifactId>
+      <version>${plugin-util-api.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-api</artifactId>
       <version>1.111</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,104 +1,115 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jvnet.hudson.plugins</groupId>
-        <artifactId>analysis-pom</artifactId>
-        <version>4.0.0</version>
-        <relativePath />
-    </parent>
-    <groupId>io.jenkins.plugins</groupId>
-    <artifactId>github-checks-api</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <java.level>8</java.level>
-        <jjwt.version>0.10.5</jjwt.version>
-    </properties>
-    <name>Jenkins GitHub Checks API plugin</name>
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>https://opensource.org/licenses/MIT</url>
-        </license>
-    </licenses>
-    <!-- Assuming you want to host on @jenkinsci:
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    </scm>
-    -->
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.jvnet.hudson.plugins</groupId>
+    <artifactId>analysis-pom</artifactId>
+    <version>4.0.0</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>io.jenkins.plugins</groupId>
+  <artifactId>github-checks-api</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <properties>
+    <java.level>8</java.level>
+    <jjwt.version>0.10.5</jjwt.version>
+  </properties>
+
+  <name>Jenkins GitHub Checks API plugin</name>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
+  <!-- Assuming you want to host on @jenkinsci:
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <scm>
+      <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+      <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+      <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  </scm>
+  -->
+  <dependencies>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>plugin-util-api</artifactId>
+      <version>1.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-api</artifactId>
+      <version>1.111</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-branch-source</artifactId>
+      <version>2.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.12</version>
+    </dependency>
+    <dependency>
+      <groupId>com.coravy.hudson.plugins.github</groupId>
+      <artifactId>github</artifactId>
+      <version>1.29.5</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${jjwt.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>${jjwt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>${jjwt.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.temp.jelly</groupId>
+      <artifactId>multiline-secrets-ui</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-api</artifactId>
-            <version>1.111</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-branch-source</artifactId>
-            <version>2.7.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jackson2-api</artifactId>
-            <version>2.11.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.12</version>
-        </dependency>
-        <dependency>
-            <groupId>com.coravy.hudson.plugins.github</groupId>
-            <artifactId>github</artifactId>
-            <version>1.29.5</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-api</artifactId>
-            <version>${jjwt.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-impl</artifactId>
-            <version>${jjwt.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
-            <version>${jjwt.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jenkins.temp.jelly</groupId>
-            <artifactId>multiline-secrets-ui</artifactId>
-            <version>1.0</version>
-        </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.9</version>
+      </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.9</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  </dependencyManagement>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,10 @@
 
   <properties>
     <java.level>8</java.level>
+
     <jjwt.version>0.10.5</jjwt.version>
+    <commons-lang3.version>3.10</commons-lang3.version>
+    <plugin-util-api.version>1.2.1</plugin-util-api.version>
   </properties>
 
   <name>Jenkins GitHub Checks API plugin</name>
@@ -39,7 +42,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>1.2.1</version>
+      <version>${plugin-util-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -89,12 +92,13 @@
       <version>1.0</version>
     </dependency>
   </dependencies>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.9</version>
+        <version>${commons-lang3.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/io/jenkins/plugins/CheckGHEventSubscriber.java
+++ b/src/main/java/io/jenkins/plugins/CheckGHEventSubscriber.java
@@ -2,24 +2,25 @@ package io.jenkins.plugins;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.kohsuke.github.GHEvent;
 import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
 import org.jenkinsci.plugins.github.extension.GHSubscriberEvent;
 import hudson.Extension;
 import hudson.model.Item;
-
-import static com.google.common.collect.Sets.immutableEnumSet;
 
 @Extension
 public class CheckGHEventSubscriber extends GHEventsSubscriber {
@@ -51,7 +52,7 @@ public class CheckGHEventSubscriber extends GHEventsSubscriber {
      */
     @Override
     protected Set<GHEvent> events() {
-        return immutableEnumSet(GHEvent.INSTALLATION_REPOSITORIES, GHEvent.CHECK_RUN, GHEvent.CHECK_SUITE);
+        return new HashSet<>(Arrays.asList(GHEvent.INSTALLATION_REPOSITORIES, GHEvent.CHECK_RUN, GHEvent.CHECK_SUITE));
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/GitHubAppConfig.java
+++ b/src/main/java/io/jenkins/plugins/GitHubAppConfig.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins;
 
+import edu.hm.hafner.util.VisibleForTesting;
+
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import hudson.Extension;
@@ -8,8 +10,11 @@ import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jenkins.model.GlobalConfiguration;
 
+import io.jenkins.plugins.util.GlobalConfigurationFacade;
+import io.jenkins.plugins.util.GlobalConfigurationItem;
+
 @Extension
-public final class GitHubAppConfig extends GlobalConfiguration {
+public final class GitHubAppConfig extends GlobalConfigurationItem {
 
     private static final String DEFAULT_APP_TITLE = "JENKINS";
     private static final String DEFAULT_APP_ID = "0";
@@ -17,9 +22,18 @@ public final class GitHubAppConfig extends GlobalConfiguration {
 
     private String appTitle = DEFAULT_APP_TITLE;
     private String appId = DEFAULT_APP_ID;
-    private Secret key = Secret.fromString(DEFAULT_KEY);
+    private Secret key;
 
     public GitHubAppConfig() {
+        key = Secret.fromString(DEFAULT_KEY);
+
+        load();
+    }
+
+    @VisibleForTesting
+    GitHubAppConfig(final GlobalConfigurationFacade facade) {
+        super(facade);
+
         load();
     }
 

--- a/src/main/java/io/jenkins/plugins/extension/CheckRunSource.java
+++ b/src/main/java/io/jenkins/plugins/extension/CheckRunSource.java
@@ -3,14 +3,13 @@ package io.jenkins.plugins.extension;
 import java.util.Date;
 import java.util.List;
 
-import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Result;
 import hudson.model.Run;
-import jenkins.model.Jenkins;
 
 import io.jenkins.plugins.CheckRunAction;
+import io.jenkins.plugins.util.JenkinsFacade;
 
 /**
  * Provides information of a check run; it will be attached to a run through the {@link CheckRunAction}
@@ -59,7 +58,7 @@ public abstract class CheckRunSource extends AbstractDescribableImpl<CheckRunSou
         return new Date(build.getDuration());
     }
 
-    public static ExtensionList<CheckRunSource> all() {
-        return Jenkins.get().getExtensionList(CheckRunSource.class);
+    public static List<CheckRunSource> all() {
+        return new JenkinsFacade().getExtensionsFor(CheckRunSource.class);
     }
 }

--- a/src/test/java/io/jenkins/plugins/ArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/ArchitectureTest.java
@@ -1,0 +1,33 @@
+package io.jenkins.plugins;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import edu.hm.hafner.util.ArchitectureRules;
+
+import io.jenkins.plugins.util.PluginArchitectureRules;
+
+/**
+ * Defines several architecture rules for the static analysis model and parsers.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("hideutilityclassconstructor")
+@AnalyzeClasses(packages = "io.jenkins.plugins..")
+class ArchitectureTest {
+    @ArchTest
+    static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;
+
+    @ArchTest
+    static final ArchRule NO_PUBLIC_TEST_CLASSES = PluginArchitectureRules.NO_PUBLIC_TEST_CLASSES;
+
+    @ArchTest
+    static final ArchRule NO_TEST_API_CALLED = ArchitectureRules.NO_TEST_API_CALLED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_PACKAGE_ACCESSED = PluginArchitectureRules.NO_FORBIDDEN_PACKAGE_ACCESSED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
+}

--- a/src/test/java/io/jenkins/plugins/GitHubAppConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/GitHubAppConfigTest.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins;
+
+import org.junit.jupiter.api.Test;
+
+import hudson.util.FormValidation.Kind;
+
+import io.jenkins.plugins.util.GlobalConfigurationFacade;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link GitHubAppConfig}.
+ *
+ * @author Ullrich Hafner
+ */
+class GitHubAppConfigTest {
+    @Test
+    void shouldValidateId() {
+        GitHubAppConfig config = new GitHubAppConfig(mock(GlobalConfigurationFacade.class));
+
+        assertThat(config.doCheckAppId("Wrong ID").kind).isEqualTo(Kind.ERROR);
+        assertThat(config.doCheckAppId("123456").kind).isEqualTo(Kind.OK);
+    }
+}


### PR DESCRIPTION
Add a `Jenkinsfile` so one can build the plugin locally in Jenkins: this helps to visualize the test results, the code and mutation coverage, and the static analysis results. Add a first test case so that PIT does not break the build because of zero tests.
  
Let the plugin depend on `plugin-utils-api` to get some assistance to make plugin code easier to test. Also add an Architecture test that forbids the usage of several libraries and classes.